### PR TITLE
Add MetaMask connect button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# cryptovend
+# CryptoVend
+
+Demo dApp that sells a pack of snacks via Ethereum smart contract.
+
+## Requirements
+* Node.js 18+
+* [MetaMask](https://metamask.io/) browser extension
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+cd backend && npm install
+cd ../frontend && npm install
+```
+
+2. In a separate terminal start a local Hardhat node:
+
+```bash
+npx hardhat node
+```
+
+3. Deploy the contract to the local network:
+
+```bash
+npx hardhat run scripts/deploy.js --network localhost
+```
+
+4. Run the backend API:
+
+```bash
+cd backend
+npm start
+```
+
+5. Run the React frontend:
+
+```bash
+cd ../frontend
+npm start
+```
+
+Open `http://localhost:3000` in the browser.
+
+## Connecting MetaMask
+
+Add a custom network in MetaMask with the following parameters:
+
+- **Network name**: Hardhat Local
+- **RPC URL**: `http://127.0.0.1:8545`
+- **Chain ID**: `31337`
+
+After that load the page and click **"Connect MetaMask"** to authorize the DApp.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,14 +6,36 @@ export default function App() {
   const [stock, setStock] = useState(0);
   const [amount, setAmount] = useState(1);
   const [status, setStatus] = useState("");
+  const [account, setAccount] = useState(null);
 
   useEffect(() => {
+    if (window.ethereum) {
+      window.ethereum
+        .request({ method: "eth_accounts" })
+        .then(accounts => accounts[0] && setAccount(accounts[0]));
+    }
     refreshStock();
   }, []);
 
   async function refreshStock() {
     const contract = getContract();
     setStock((await contract.stock()).toString());
+  }
+
+  async function connect() {
+    if (!window.ethereum) {
+      setStatus("Установите MetaMask");
+      return;
+    }
+    try {
+      const [acc] = await window.ethereum.request({
+        method: "eth_requestAccounts"
+      });
+      setAccount(acc);
+      setStatus("");
+    } catch (e) {
+      setStatus("Ошибка подключения: " + e.message);
+    }
   }
 
   async function buy() {
@@ -34,6 +56,11 @@ export default function App() {
   return (
     <div style={{ maxWidth: 500, margin: "40px auto", fontFamily: "sans-serif" }}>
       <h1>Крипто-вендинг: Кириешки</h1>
+      {!account ? (
+        <button onClick={connect}>Подключить MetaMask</button>
+      ) : (
+        <p>Подключено: {account}</p>
+      )}
       <p>В наличии: {stock} пачек</p>
       <label>
         Сколько купить:

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,4 +15,3 @@ module.exports = {
     }
   }
 };
-`


### PR DESCRIPTION
## Summary
- add instructions for running the dapp and connecting MetaMask
- show connect button in the React frontend
- fix stray character in Hardhat config

## Testing
- `npm test` *(fails: missing script)*
- `npm --prefix backend test` *(fails: missing script)*
- `npm --prefix frontend test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68404fe23f2083318c35361d11f4bfbf