### PR TITLE
Fix async signer retrieval in frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,7 +18,7 @@ export default function App() {
   }, []);
 
   async function refreshStock() {
-    const contract = getContract();
+    const contract = await getContract();
     setStock((await contract.stock()).toString());
   }
 
@@ -40,7 +40,7 @@ export default function App() {
 
   async function buy() {
     try {
-      const contract = getContract();
+      const contract = await getContract();
       const tx = await contract.buy(amount, {
         value: ethers.parseEther((0.01 * amount).toString())
       });

--- a/frontend/src/utils/contract.js
+++ b/frontend/src/utils/contract.js
@@ -2,9 +2,9 @@ import vendingAbi from "../../../artifacts/contracts/VendingMachine.sol/VendingM
 import addressJson from "../../../address.json" assert { type: "json" };
 import { ethers } from "ethers";
 
-export function getContract() {
+export async function getContract() {
   if (!window.ethereum) throw new Error("Metamask required");
   const provider = new ethers.BrowserProvider(window.ethereum);
-  const signer = provider.getSigner();
+  const signer = await provider.getSigner();
   return new ethers.Contract(addressJson.address, vendingAbi.abi, signer);
 }


### PR DESCRIPTION
## Summary
- make `getContract` async and await signer retrieval
- await `getContract` before calling contract methods in the app

## Testing
- `npm run build` *(fails: Could not find required file `index.html`)*
- `npx -y hardhat compile` *(fails: Trying to use a non-local installation of Hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68405ffe2a14833195d68a9da9c425b0